### PR TITLE
图片选择器中缺失部分图片

### DIFF
--- a/multi-image-selector/src/main/java/me/nereo/multi_image_selector/MultiImageSelectorFragment.java
+++ b/multi-image-selector/src/main/java/me/nereo/multi_image_selector/MultiImageSelectorFragment.java
@@ -412,8 +412,7 @@ public class MultiImageSelectorFragment extends Fragment {
             if(id == LOADER_ALL) {
                 CursorLoader cursorLoader = new CursorLoader(getActivity(),
                         MediaStore.Images.Media.EXTERNAL_CONTENT_URI, IMAGE_PROJECTION,
-                        IMAGE_PROJECTION[4]+">0 AND "+IMAGE_PROJECTION[3]+"=? OR "+IMAGE_PROJECTION[3]+"=? ",
-                        new String[]{"image/jpeg", "image/png"}, IMAGE_PROJECTION[2] + " DESC");
+                        IMAGE_PROJECTION[4]+">0 ", null, IMAGE_PROJECTION[2] + " DESC");
                 return cursorLoader;
             }else if(id == LOADER_CATEGORY){
                 CursorLoader cursorLoader = new CursorLoader(getActivity(),


### PR DESCRIPTION
现有查询条件的MIME type: image/jpeg和image/png无法选择出MIME type是_/_的图片,导致选择器缺失部分图片。
